### PR TITLE
More dockerization

### DIFF
--- a/examples/cmd/data/main.go
+++ b/examples/cmd/data/main.go
@@ -39,7 +39,7 @@ func main() {
 		eps,
 	)
 
-	info("registering %s with gsr.", myAddr)
+	info("registering %s with gsr as a %s service endpoint.", myAddr, myServiceName)
 	ep := gsr.Endpoint{
 		Service: &gsr.Service{Name: myServiceName},
 		Address: myAddr,

--- a/examples/cmd/web/main.go
+++ b/examples/cmd/web/main.go
@@ -39,7 +39,7 @@ func main() {
 		eps,
 	)
 
-	info("registering %s with gsr.", myAddr)
+	info("registering %s with gsr as a %s service endpoint.", myAddr, myServiceName)
 	ep := gsr.Endpoint{
 		Service: &gsr.Service{Name: myServiceName},
 		Address: myAddr,

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -41,7 +41,7 @@ docker run -d \
     -e "GSR_LOG_LEVEL=3" \
     -e "GSR_ETCD_ENDPOINTS=http://$GSR_TEST_ETCD_HOST:2379" \
     -e "GSR_ETCD_CONNECT_TIMEOUT_SECONDS=3" \
-    gsr-example-data:latest \
+    gsr-example-data:$VERSION \
     /app/main 2>&1 >/dev/null
 echo "ok."
 
@@ -58,7 +58,7 @@ docker run -d \
     -e "GSR_LOG_LEVEL=3" \
     -e "GSR_ETCD_ENDPOINTS=http://$GSR_TEST_ETCD_HOST:2379" \
     -e "GSR_ETCD_CONNECT_TIMEOUT_SECONDS=3" \
-    gsr-example-web:latest \
+    gsr-example-web:$VERSION \
     /app/main 2>&1 >/dev/null
 echo "ok."
 

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -3,6 +3,7 @@
 DEBUG=${DEBUG:-0}
 DATA_DIR=$(mktemp -d -t gsr-example-XXXXXX)
 EXAMPLES_DIR=$(cd $(dirname "$0")/ && pwd)
+VERSION=`git describe --tags --always --dirty`
 
 source $EXAMPLES_DIR/common.bash
 
@@ -21,11 +22,11 @@ fi
 
 echo "Building Docker image for example data service ... "
 cd $EXAMPLES_DIR/cmd/data
-docker build -t gsr-example-data . -f Dockerfile
+docker build -t gsr-example-data:$VERSION . -f Dockerfile
 
 echo "Building Docker image for example web service ... "
 cd $EXAMPLES_DIR/cmd/web
-docker build -t gsr-example-web . -f Dockerfile
+docker build -t gsr-example-web:$VERSION . -f Dockerfile
 
 start_etcd_container && get_etcd_address
 


### PR DESCRIPTION
Some final cleanup on the `examples/run.sh` script to remove stdout mess when building images or running them via Docker.

Output now clean and matches the README's general instructions:

```
Building Docker image for example data service ... ok.
Building Docker image for example web service ... ok.
Starting etcd container for gsr tests (data-dir: /tmp/gsr-example-wJhmsC)... ok.
Determining etcd3 endpoint address ... ok.
etcd running in container at 172.17.0.2:2379.
Starting gsr-example-data container ... ok.
Logs from gsr-example-data container:
2018/10/12 14:32:02 [data:172.17.0.3:9000] starting data service on 172.17.0.3:9000.
2018/10/12 14:32:02 [data:172.17.0.3:9000] GSR_ETCD_ENDPOINTS is set to http://172.17.0.2:2379
2018/10/12 14:32:02 [data:172.17.0.3:9000] GSR_ETCD_CONNECT_TIMEOUT_SECONDS is set to 3
2018/10/12 14:32:02 [data:172.17.0.3:9000] GSR_LOG_LEVEL is set to 3
2018/10/12 14:32:02 [data:172.17.0.3:9000] connecting to gsr.
2018/10/12 14:32:02 [gsr] connecting to etcd endpoints [http://172.17.0.2:2379] (w/ 3s overall timeout).
2018/10/12 14:32:02 [gsr] connected to registry.
2018/10/12 14:32:02 [gsr] creating watch on gsr/services/
2018/10/12 14:32:02 [gsr] read 0 endpoints @ generation 1
2018/10/12 14:32:02 [data:172.17.0.3:9000] before registering itself, data service knows about endpoints: []
2018/10/12 14:32:02 [data:172.17.0.3:9000] registering 172.17.0.3:9000 with gsr as a data service endpoint.
2018/10/12 14:32:02 [gsr] read 0 endpoints @ generation 1
2018/10/12 14:32:02 [gsr] creating new registry entry for data:172.17.0.3:9000
2018/10/12 14:32:02 [gsr] received notification that data:172.17.0.3:9000 was created. 
2018/10/12 14:32:02 [gsr] started heartbeat channel
2018/10/12 14:32:02 [data:172.17.0.3:9000] listening for HTTP traffic on 172.17.0.3:9000.
Starting gsr-example-web container ... ok.
Logs from gsr-example-web container:
2018/10/12 14:32:08 [web:172.17.0.4:8080] starting web service on 172.17.0.4:8080.
2018/10/12 14:32:08 [web:172.17.0.4:8080] GSR_LOG_LEVEL is set to 3
2018/10/12 14:32:08 [web:172.17.0.4:8080] GSR_ETCD_ENDPOINTS is set to http://172.17.0.2:2379
2018/10/12 14:32:08 [web:172.17.0.4:8080] GSR_ETCD_CONNECT_TIMEOUT_SECONDS is set to 3
2018/10/12 14:32:08 [web:172.17.0.4:8080] connecting to gsr.
2018/10/12 14:32:08 [gsr] connecting to etcd endpoints [http://172.17.0.2:2379] (w/ 3s overall timeout).
2018/10/12 14:32:08 [gsr] connected to registry.
2018/10/12 14:32:08 [gsr] creating watch on gsr/services/
2018/10/12 14:32:08 [gsr] read 1 endpoints @ generation 2
2018/10/12 14:32:08 [web:172.17.0.4:8080] before registering itself, web service knows about endpoints: [data:172.17.0.3:9000]
2018/10/12 14:32:08 [web:172.17.0.4:8080] registering 172.17.0.4:8080 with gsr as a web service endpoint.
2018/10/12 14:32:08 [gsr] read 0 endpoints @ generation 2
2018/10/12 14:32:08 [gsr] creating new registry entry for web:172.17.0.4:8080
2018/10/12 14:32:08 [gsr] received notification that web:172.17.0.4:8080 was created. 
2018/10/12 14:32:08 [gsr] started heartbeat channel
2018/10/12 14:32:08 [web:172.17.0.4:8080] listening for HTTP traffic on 172.17.0.4:8080.
Logs from gsr-example-data container:
2018/10/12 14:32:02 [data:172.17.0.3:9000] starting data service on 172.17.0.3:9000.
2018/10/12 14:32:02 [data:172.17.0.3:9000] GSR_ETCD_ENDPOINTS is set to http://172.17.0.2:2379
2018/10/12 14:32:02 [data:172.17.0.3:9000] GSR_ETCD_CONNECT_TIMEOUT_SECONDS is set to 3
2018/10/12 14:32:02 [data:172.17.0.3:9000] GSR_LOG_LEVEL is set to 3
2018/10/12 14:32:02 [data:172.17.0.3:9000] connecting to gsr.
2018/10/12 14:32:02 [gsr] connecting to etcd endpoints [http://172.17.0.2:2379] (w/ 3s overall timeout).
2018/10/12 14:32:02 [gsr] connected to registry.
2018/10/12 14:32:02 [gsr] creating watch on gsr/services/
2018/10/12 14:32:02 [gsr] read 0 endpoints @ generation 1
2018/10/12 14:32:02 [data:172.17.0.3:9000] before registering itself, data service knows about endpoints: []
2018/10/12 14:32:02 [data:172.17.0.3:9000] registering 172.17.0.3:9000 with gsr as a data service endpoint.
2018/10/12 14:32:02 [gsr] read 0 endpoints @ generation 1
2018/10/12 14:32:02 [gsr] creating new registry entry for data:172.17.0.3:9000
2018/10/12 14:32:02 [gsr] received notification that data:172.17.0.3:9000 was created. 
2018/10/12 14:32:02 [gsr] started heartbeat channel
2018/10/12 14:32:02 [data:172.17.0.3:9000] listening for HTTP traffic on 172.17.0.3:9000.
2018/10/12 14:32:08 [gsr] received notification that web:172.17.0.4:8080 was created. 
Killing example data containers ... 
gsr-example-data
Logs from gsr-example-web container:
2018/10/12 14:32:08 [web:172.17.0.4:8080] starting web service on 172.17.0.4:8080.
2018/10/12 14:32:08 [web:172.17.0.4:8080] GSR_LOG_LEVEL is set to 3
2018/10/12 14:32:08 [web:172.17.0.4:8080] GSR_ETCD_ENDPOINTS is set to http://172.17.0.2:2379
2018/10/12 14:32:08 [web:172.17.0.4:8080] GSR_ETCD_CONNECT_TIMEOUT_SECONDS is set to 3
2018/10/12 14:32:08 [web:172.17.0.4:8080] connecting to gsr.
2018/10/12 14:32:08 [gsr] connecting to etcd endpoints [http://172.17.0.2:2379] (w/ 3s overall timeout).
2018/10/12 14:32:08 [gsr] connected to registry.
2018/10/12 14:32:08 [gsr] creating watch on gsr/services/
2018/10/12 14:32:08 [gsr] read 1 endpoints @ generation 2
2018/10/12 14:32:08 [web:172.17.0.4:8080] before registering itself, web service knows about endpoints: [data:172.17.0.3:9000]
2018/10/12 14:32:08 [web:172.17.0.4:8080] registering 172.17.0.4:8080 with gsr as a web service endpoint.
2018/10/12 14:32:08 [gsr] read 0 endpoints @ generation 2
2018/10/12 14:32:08 [gsr] creating new registry entry for web:172.17.0.4:8080
2018/10/12 14:32:08 [gsr] received notification that web:172.17.0.4:8080 was created. 
2018/10/12 14:32:08 [gsr] started heartbeat channel
2018/10/12 14:32:08 [web:172.17.0.4:8080] listening for HTTP traffic on 172.17.0.4:8080.
Killing example web and etcd containers ... ok.
```